### PR TITLE
fix: Tokenizer max length edge case + noisy encoding

### DIFF
--- a/mxbai_rerank/mxbai_rerank_v2.py
+++ b/mxbai_rerank/mxbai_rerank_v2.py
@@ -5,9 +5,7 @@ from typing import ClassVar, Dict, List, Optional
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
-# Remove the transformers spam because of separate encoder calls
 from transformers.utils.logging import set_verbosity_error
-set_verbosity_error()
 
 from mxbai_rerank.base import BaseReranker
 from mxbai_rerank.utils import TorchModule, auto_device, ensure_multiple_of_8
@@ -48,6 +46,7 @@ class MxbaiRerankV2(BaseReranker, TorchModule):
         torch_dtype: str | torch.dtype = "auto",
         max_length: int = 8192,
         tokenizer_kwargs: Optional[dict] = None,
+        disable_transformers_warnings: bool = False,
         **kwargs,
     ):
         """Initialize the classifier model.
@@ -61,6 +60,9 @@ class MxbaiRerankV2(BaseReranker, TorchModule):
         """
         TorchModule.__init__(self)
         tokenizer_kwargs = tokenizer_kwargs or {}
+
+        if disable_transformers_warnings:
+            set_verbosity_error()
 
         self.model = AutoModelForCausalLM.from_pretrained(
             model_name_or_path,

--- a/mxbai_rerank/mxbai_rerank_v2.py
+++ b/mxbai_rerank/mxbai_rerank_v2.py
@@ -5,6 +5,9 @@ from typing import ClassVar, Dict, List, Optional
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
+# Remove the transformers spam because of separate encoder calls
+from transformers.utils.logging import set_verbosity_error
+set_verbosity_error()
 
 from mxbai_rerank.base import BaseReranker
 from mxbai_rerank.utils import TorchModule, auto_device, ensure_multiple_of_8
@@ -172,7 +175,7 @@ class MxbaiRerankV2(BaseReranker, TorchModule):
         # Pad all sequences to same length
         return self.tokenizer.pad(
             inputs,
-            padding=True,
+            padding="longest",
             max_length=self.max_length_padding,
             pad_to_multiple_of=8,  # For efficient tensor operations
             return_tensors="pt",

--- a/mxbai_rerank/utils.py
+++ b/mxbai_rerank/utils.py
@@ -62,17 +62,25 @@ def ensure_multiple_of_8(x: int, max_value: Optional[int] = None) -> int:
         max_value: The maximum value that the result should not exceed.
 
     Returns:
-        The largest multiple of 8 that is less than or equal to max_value if max_value is provided.
+        The nearest multiple of 8 that is greater than or equal to x,
+        unless that would exceed max_value, in which case returns the
+        largest multiple of 8 that is less than or equal to max_value.
     """
     if max_value is not None:
         max_value -= max_value % 8
-        if x > max_value:
-            x = max_value
-
+        
     remainder = x % 8
     if remainder == 0:
         return x
-    return x - remainder
+    
+    # Round up to next multiple of 8
+    next_multiple = x + (8 - remainder)
+    
+    # Check if the next multiple exceeds max_value
+    if max_value is not None and next_multiple > max_value:
+        return max_value
+    
+    return next_multiple
 
 
 CPU_INCOMPATIBLE_DTYPE = [torch.float16, torch.bfloat16, torch.half]

--- a/mxbai_rerank/utils.py
+++ b/mxbai_rerank/utils.py
@@ -54,19 +54,25 @@ def auto_device() -> str:
     return "cpu"
 
 
-def ensure_multiple_of_8(x: int) -> int:
+def ensure_multiple_of_8(x: int, max_value: Optional[int] = None) -> int:
     """Ensure a number is a multiple of 8.
 
     Args:
         x: The number to ensure is a multiple of 8.
+        max_value: The maximum value that the result should not exceed.
 
     Returns:
-        The smallest multiple of 8 that is greater than or equal to x.
+        The largest multiple of 8 that is less than or equal to max_value if max_value is provided.
     """
+    if max_value is not None:
+        max_value -= max_value % 8
+        if x > max_value:
+            x = max_value
+
     remainder = x % 8
     if remainder == 0:
         return x
-    return x + (8 - remainder)
+    return x - remainder
 
 
 CPU_INCOMPATIBLE_DTYPE = [torch.float16, torch.bfloat16, torch.half]


### PR DESCRIPTION
Hey,

Currently integrating the model into `rerankers` and thought I'd upstream these minor changes:

- Modify the max length logic as it was failing a quick test: when trying to max length document, it'd error out as the templating pushed it above the allowed limit. Also ensures that the multiple_of_8 util doesn't accidentally exceed the model max length.
- Decouple a user-defined max length from the model's max length, in case the max length is set for clear reasons ( domain knowledge for example, eg ArguAna) that shouldn't affect the inner workings of templating, etc...
- Addresses https://github.com/mixedbread-ai/mxbai-rerank/issues/2 as it's a very minor related change to make

cc @juliuslipp 