### PR TITLE
fix: Ensure tokenizer max length is model-appropriate

### DIFF
--- a/mxbai_rerank/utils.py
+++ b/mxbai_rerank/utils.py
@@ -68,18 +68,18 @@ def ensure_multiple_of_8(x: int, max_value: Optional[int] = None) -> int:
     """
     if max_value is not None:
         max_value -= max_value % 8
-        
+
     remainder = x % 8
     if remainder == 0:
         return x
-    
+
     # Round up to next multiple of 8
     next_multiple = x + (8 - remainder)
-    
+
     # Check if the next multiple exceeds max_value
     if max_value is not None and next_multiple > max_value:
         return max_value
-    
+
     return next_multiple
 
 


### PR DESCRIPTION
Quick follow-up to https://github.com/mixedbread-ai/mxbai-rerank/pull/3

Ran into another issue as I'd forgotten that Qwen models have a mean tendency to set `model_max_length` in their tokenizer to the length of their biggest model, but the smaller ones actually have way lower config sizes. Modifying this so that the default/upper bound max length is fetched directly from the model's config rather than the treacherous tokenizer.

(also applying proper linting with the repo's ruff rules)
@juliuslipp 