### PR TITLE
Passing kwargs to AutoConfig.from_pretrained

### DIFF
--- a/mxbai_rerank/mxbai_rerank_v2.py
+++ b/mxbai_rerank/mxbai_rerank_v2.py
@@ -83,7 +83,7 @@ class MxbaiRerankV2(BaseReranker, TorchModule):
         )
         self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, **tokenizer_kwargs)
         self.tokenizer.padding_side = "left"
-        self.cfg = AutoConfig.from_pretrained(model_name_or_path)
+        self.cfg = AutoConfig.from_pretrained(model_name_or_path, **kwargs)
         self.max_length = max_length or self.cfg.max_position_embeddings
         self.model_max_length = self.cfg.max_position_embeddings
         self.estimated_max = estimated_max


### PR DESCRIPTION
This pull request includes a minor update to the initialization method in the `mxbai_rerank_v2.py` file to improve configurability.

I have updated the `AutoConfig.from_pretrained` call to accept additional keyword arguments (`**kwargs`), allowing for more flexible configuration during initialization.

My use case is loading the model offline from a specific cache_dir. 