### PR TITLE
nit: add a post-init padding_side definition to safeguard padding

### DIFF
--- a/mxbai_rerank/mxbai_rerank_v2.py
+++ b/mxbai_rerank/mxbai_rerank_v2.py
@@ -82,6 +82,7 @@ class MxbaiRerankV2(BaseReranker, TorchModule):
             },
         )
         self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, padding_side="left", **tokenizer_kwargs)
+        self.tokenizer.padding_side = "left"  # Duplicated overwrite to address reported issues with certain versions of transformers ignoring the constructor args.
         self.cfg = AutoConfig.from_pretrained(model_name_or_path, **kwargs)
         self.max_length = max_length or self.cfg.max_position_embeddings
         self.model_max_length = self.cfg.max_position_embeddings


### PR DESCRIPTION
Minor PR to fix the issue that some users have been experiencing with Qwen2's tokenizer, where caching issues make it so that the tokenizer sometimes ignores constructor arguments. This should be fixed in recent versions of transformers but his fix is essentially free and ensures everyone gets the expected behaviour.